### PR TITLE
Make Sun of type 'Star' instead of 'Sun'

### DIFF
--- a/COUVIS/SOLAR_SYSTEM_TARGETS.py
+++ b/COUVIS/SOLAR_SYSTEM_TARGETS.py
@@ -5,7 +5,7 @@
 ####################################################################################################################################################
 
 SOLAR_SYSTEM_TARGETS = [
-  ("Sun"           , ["NAIF ID 10"               ], "Sun"      , "N/A"    , "urn:nasa:pds:context:target:star.sun"                                 ),
+  ("Sun"           , ["NAIF ID 10"               ], "Star"      , "N/A"    , "urn:nasa:pds:context:target:star.sun"                                 ),
   ("Mercury"       , ["NAIF ID 199"              ], "Planet"   , "Sun"    , "urn:nasa:pds:context:target:planet.mercury"                           ),
   ("Venus"         , ["NAIF ID 299"              ], "Planet"   , "Sun"    , "urn:nasa:pds:context:target:planet.venus"                             ),
 


### PR DESCRIPTION
Labels with the Sun as the target do not pass validation as the `type` is `Sun` rather than a permitted type.

The Validate tool's error message states: 
`
ERROR  [error.label.schematron] .... The attribute pds:Target_Identification/pds:type must be equal to one of the following values 'Asteroid', 'Astrophysical', 'Calibration', 'Calibration Field', 'Calibrator', 'Centaur', Comet', 'Dust', 'Dwarf Planet', 'Equipment', 'Exoplanet System', 'Galaxy', 'Globular Cluster', 'Laboratory Analog', 'Lunar Sample', 'Magnetic Field', 'Meterorite', 'Meteoroid', 'Meteoroid Stream', 'Nebula', 'Open Cluster', 'Planet', 'Planetary Nebula', 'Planetary System', 'Plasma Cloud', 'Plasma Stream', 'Ring', 'Sample', 'Satellite', 'Star', 'Star Cluster', 'Synthetic Sample', 'Terrestrial Sample', 'Trans-Neptunian Object'.
`